### PR TITLE
Add Redis broker configuration

### DIFF
--- a/mydjangoapp/compose/development.yml
+++ b/mydjangoapp/compose/development.yml
@@ -9,6 +9,7 @@ services:
       - "8000:8000"
     environment:
       - DJANGO_SETTINGS_MODULE=config.settings.dev
+      - CELERY_BROKER_URL=redis://redis:6379/0
   worker:
     build: .
     command: celery -A config worker -l info
@@ -16,5 +17,11 @@ services:
       - .:/code
     environment:
       - DJANGO_SETTINGS_MODULE=config.settings.dev
+      - CELERY_BROKER_URL=redis://redis:6379/0
     depends_on:
       - web
+      - redis
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"

--- a/mydjangoapp/compose/production.yml
+++ b/mydjangoapp/compose/production.yml
@@ -5,6 +5,7 @@ services:
     command: gunicorn config.wsgi:application --bind 0.0.0.0:8000
     environment:
       - DJANGO_SETTINGS_MODULE=config.settings.prod
+      - CELERY_BROKER_URL=redis://redis:6379/0
     ports:
       - "8000:8000"
   worker:
@@ -12,3 +13,8 @@ services:
     command: celery -A config worker -l info
     environment:
       - DJANGO_SETTINGS_MODULE=config.settings.prod
+      - CELERY_BROKER_URL=redis://redis:6379/0
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"

--- a/mydjangoapp/config/celery.py
+++ b/mydjangoapp/config/celery.py
@@ -4,4 +4,5 @@ from celery import Celery
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'config.settings.dev')
 app = Celery('mydjangoapp')
 app.config_from_object('django.conf:settings', namespace='CELERY')
+app.conf.broker_url = os.getenv('CELERY_BROKER_URL', 'redis://redis:6379/0')
 app.autodiscover_tasks()

--- a/mydjangoapp/config/settings/dev.py
+++ b/mydjangoapp/config/settings/dev.py
@@ -1,3 +1,3 @@
-from .base import *
+from .base import *  # noqa: F403
 
 DEBUG = True

--- a/mydjangoapp/config/settings/prod.py
+++ b/mydjangoapp/config/settings/prod.py
@@ -1,3 +1,3 @@
-from .base import *
+from .base import *  # noqa: F403
 
 DEBUG = False


### PR DESCRIPTION
## Summary
- add redis to compose files
- configure celery broker URL
- silence ruff errors in dev/prod settings

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68430a83cc38832fbe0734541eafa7a2