### PR TITLE
Add Celery Beat integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ railway up
 * Defina variáveis de ambiente no dashboard
 * Serviço web: `gunicorn config.wsgi:application --log-file -`
 * Serviço worker: `celery -A config worker -l info`
+* Serviço beat: `celery -A config beat -l info -S django`
 * Configure autoscale e domínio customizado
 
 ### VPS (Ubuntu 22.04 + Docker)

--- a/mydjangoapp/compose/development.yml
+++ b/mydjangoapp/compose/development.yml
@@ -21,6 +21,17 @@ services:
     depends_on:
       - web
       - redis
+  beat:
+    build: .
+    command: celery -A config beat -l info -S django
+    volumes:
+      - .:/code
+    environment:
+      - DJANGO_SETTINGS_MODULE=config.settings.dev
+      - CELERY_BROKER_URL=redis://redis:6379/0
+    depends_on:
+      - web
+      - redis
   redis:
     image: redis:7-alpine
     ports:

--- a/mydjangoapp/compose/production.yml
+++ b/mydjangoapp/compose/production.yml
@@ -14,6 +14,12 @@ services:
     environment:
       - DJANGO_SETTINGS_MODULE=config.settings.prod
       - CELERY_BROKER_URL=redis://redis:6379/0
+  beat:
+    build: .
+    command: celery -A config beat -l info -S django
+    environment:
+      - DJANGO_SETTINGS_MODULE=config.settings.prod
+      - CELERY_BROKER_URL=redis://redis:6379/0
   redis:
     image: redis:7-alpine
     ports:

--- a/mydjangoapp/config/settings/base.py
+++ b/mydjangoapp/config/settings/base.py
@@ -12,6 +12,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'django_celery_beat',
     'apps.core',
 ]
 MIDDLEWARE = [
@@ -47,3 +48,12 @@ DATABASES = {
 }
 STATIC_URL = 'static/'
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+
+from celery.schedules import crontab
+
+CELERY_BEAT_SCHEDULE = {
+    'fetch-contests-every-6-hours': {
+        'task': 'apps.core.tasks.fetch_contests',
+        'schedule': crontab(minute=0, hour='*/6'),
+    }
+}

--- a/mydjangoapp/pyproject.toml
+++ b/mydjangoapp/pyproject.toml
@@ -8,6 +8,7 @@ authors = ["Seu Nome <voce@example.com>"]
 python = "^3.12"
 django = "^5.2"
 celery = "^5.3"
+django-celery-beat = "^2.5"
 requests = "^2.31"
 beautifulsoup4 = "^4.12"
 

--- a/mydjangoapp/tests/test_schedule.py
+++ b/mydjangoapp/tests/test_schedule.py
@@ -1,0 +1,10 @@
+from django.conf import settings
+from django.test import TestCase
+from celery.schedules import crontab
+
+
+class BeatConfigTest(TestCase):
+    def test_fetch_contests_task_is_scheduled(self):
+        schedule = settings.CELERY_BEAT_SCHEDULE['fetch-contests-every-6-hours']
+        assert schedule['task'] == 'apps.core.tasks.fetch_contests'
+        assert schedule['schedule'] == crontab(minute=0, hour='*/6')


### PR DESCRIPTION
## Summary
- install django-celery-beat
- schedule `fetch_contests` task to run every 6 hours
- add celery beat service to docker compose files
- document beat command in README
- test that beat schedule is configured

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6844aa9c73d4832fb75d28cfd2c24869