### PR TITLE
Add PDF/Excel export

### DIFF
--- a/mydjangoapp/apps/core/views.py
+++ b/mydjangoapp/apps/core/views.py
@@ -1,5 +1,18 @@
+from django.http import HttpResponse
 from django.shortcuts import render
+from django.template.loader import render_to_string
 from .models import Contest
+import io
+
+try:
+    import weasyprint  # type: ignore
+except Exception:  # pragma: no cover - dependency optional
+    weasyprint = None
+
+try:
+    from openpyxl import Workbook  # type: ignore
+except Exception:  # pragma: no cover - dependency optional
+    Workbook = None
 
 
 def contest_list(request):
@@ -11,3 +24,46 @@ def contest_list(request):
     if state:
         contests = contests.filter(state__iexact=state)
     return render(request, 'contest_list.html', {'contests': contests})
+
+
+def export_contests(request):
+    """Export contests filtered by query parameters as PDF or Excel."""
+    contests = Contest.objects.all()
+    query = request.GET.get('q')
+    if query:
+        contests = contests.filter(title__icontains=query)
+    state = request.GET.get('state')
+    if state:
+        contests = contests.filter(state__iexact=state)
+
+    fmt = request.GET.get('format', 'pdf')
+
+    if fmt == 'excel' and Workbook is not None:
+        wb = Workbook()
+        ws = wb.active
+        ws.append(['Title', 'Organization', 'State', 'Deadline', 'URL'])
+        for c in contests:
+            ws.append([c.title, c.organization, c.state, c.deadline, c.url])
+        output = io.BytesIO()
+        wb.save(output)
+        output.seek(0)
+        response = HttpResponse(
+            output.read(),
+            content_type='application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+        )
+        response['Content-Disposition'] = 'attachment; filename="contests.xlsx"'
+        return response
+
+    if fmt == 'pdf' and weasyprint is not None:
+        html_string = render_to_string('export_pdf.html', {'contests': contests})
+        html = weasyprint.HTML(string=html_string)
+        pdf_bytes = html.write_pdf()
+        response = HttpResponse(pdf_bytes, content_type='application/pdf')
+        response['Content-Disposition'] = 'attachment; filename="contests.pdf"'
+        return response
+
+    # fallback to plain text listing
+    lines = [
+        f"{c.title}\t{c.organization}\t{c.state}\t{c.deadline}\t{c.url}" for c in contests
+    ]
+    return HttpResponse('\n'.join(lines), content_type='text/plain')

--- a/mydjangoapp/config/urls.py
+++ b/mydjangoapp/config/urls.py
@@ -5,4 +5,5 @@ from apps.core import views
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('', views.contest_list, name='contest_list'),
+    path('export/', views.export_contests, name='contest_export'),
 ]

--- a/mydjangoapp/pyproject.toml
+++ b/mydjangoapp/pyproject.toml
@@ -10,6 +10,8 @@ django = "^5.2"
 celery = "^5.3"
 requests = "^2.31"
 beautifulsoup4 = "^4.12"
+weasyprint = "^61.0"
+openpyxl = "^3.1"
 
 [tool.poetry.dev-dependencies]
 pytest = "^8.2"

--- a/mydjangoapp/templates/contest_list.html
+++ b/mydjangoapp/templates/contest_list.html
@@ -10,6 +10,10 @@
     <input type="text" name="state" placeholder="UF" value="{{ request.GET.state }}">
     <button type="submit">Filtrar</button>
 </form>
+<p>
+    <a href="{% url 'contest_export' %}?q={{ request.GET.q }}&state={{ request.GET.state }}&format=pdf">Exportar PDF</a> |
+    <a href="{% url 'contest_export' %}?q={{ request.GET.q }}&state={{ request.GET.state }}&format=excel">Exportar Excel</a>
+</p>
 <ul>
 {% for contest in contests %}
     <li><a href="{{ contest.url }}">{{ contest.title }}</a> - {{ contest.state }}</li>

--- a/mydjangoapp/templates/export_pdf.html
+++ b/mydjangoapp/templates/export_pdf.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Contests</title>
+</head>
+<body>
+    <h1>Concursos</h1>
+    <table>
+        <thead>
+            <tr>
+                <th>Titulo</th>
+                <th>Org</th>
+                <th>UF</th>
+                <th>Data</th>
+                <th>URL</th>
+            </tr>
+        </thead>
+        <tbody>
+        {% for contest in contests %}
+            <tr>
+                <td>{{ contest.title }}</td>
+                <td>{{ contest.organization }}</td>
+                <td>{{ contest.state }}</td>
+                <td>{{ contest.deadline }}</td>
+                <td>{{ contest.url }}</td>
+            </tr>
+        {% endfor %}
+        </tbody>
+    </table>
+</body>
+</html>

--- a/mydjangoapp/tests/test_views.py
+++ b/mydjangoapp/tests/test_views.py
@@ -27,3 +27,21 @@ class ContestListViewTest(TestCase):
         assert "Concurso B" in content
         assert "Concurso A" not in content
 
+    def test_export_pdf(self):
+        weasyprint = __import__('importlib').import_module('importlib').import_module('weasyprint') if __import__('importlib').import_module('importlib').util.find_spec('weasyprint') else None
+        if not weasyprint:
+            self.skipTest('weasyprint not installed')
+        response = self.client.get(reverse("contest_export") + "?format=pdf")
+        assert response.status_code == 200
+        assert response['Content-Type'] == 'application/pdf'
+        assert response.content.startswith(b'%PDF')
+
+    def test_export_excel(self):
+        openpyxl_spec = __import__('importlib').import_module('importlib').util.find_spec('openpyxl')
+        if not openpyxl_spec:
+            self.skipTest('openpyxl not installed')
+        response = self.client.get(reverse("contest_export") + "?format=excel")
+        assert response.status_code == 200
+        assert response['Content-Type'].startswith('application/vnd.openxmlformats')
+
+


### PR DESCRIPTION
## Summary
- implement export endpoint for contests
- add PDF and Excel generation
- expose export route
- link export buttons in template
- test export endpoint
- include new dependencies for export

## Testing
- `make test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6844aa9dd39c832fbf19d7f9475d457f