### PR TITLE
Implement favorites and custom user

### DIFF
--- a/mydjangoapp/apps/core/__init__.py
+++ b/mydjangoapp/apps/core/__init__.py
@@ -1,1 +1,2 @@
 
+from . import signals  # noqa: F401

--- a/mydjangoapp/apps/core/migrations/0002_favorite.py
+++ b/mydjangoapp/apps/core/migrations/0002_favorite.py
@@ -1,0 +1,24 @@
+from django.db import migrations, models
+import django.db.models.deletion
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('core', '0001_initial'),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='Favorite',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('created_at', models.DateTimeField(auto_now_add=True)),
+                ('contest', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='core.contest')),
+                ('user', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to=settings.AUTH_USER_MODEL)),
+            ],
+            options={'unique_together': {('user', 'contest')}},
+        ),
+    ]

--- a/mydjangoapp/apps/core/models.py
+++ b/mydjangoapp/apps/core/models.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.db import models
 
 class Contest(models.Model):
@@ -9,3 +10,15 @@ class Contest(models.Model):
 
     def __str__(self):
         return self.title
+
+
+class Favorite(models.Model):
+    user = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
+    contest = models.ForeignKey(Contest, on_delete=models.CASCADE)
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        unique_together = ("user", "contest")
+
+    def __str__(self) -> str:  # pragma: no cover - simple
+        return f"{self.user} -> {self.contest}"

--- a/mydjangoapp/apps/core/signals.py
+++ b/mydjangoapp/apps/core/signals.py
@@ -1,0 +1,11 @@
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+
+from .models import Contest
+from .tasks import send_update_email
+
+
+@receiver(post_save, sender=Contest)
+def notify_favorite_update(sender, instance, created, **kwargs):
+    if not created:
+        send_update_email.delay(instance.id)

--- a/mydjangoapp/apps/core/tasks.py
+++ b/mydjangoapp/apps/core/tasks.py
@@ -1,6 +1,7 @@
 from celery import shared_task
 import requests
 from bs4 import BeautifulSoup
+from django.core.mail import send_mail
 from .models import Contest
 
 PCI_URL = 'https://www.pciconcursos.com.br/'
@@ -11,6 +12,21 @@ def fetch_contests():
     response.raise_for_status()
     soup = BeautifulSoup(response.text, 'html.parser')
     # Esta é apenas uma ilustração simplificada
-    for item in soup.select('.caixa-organizador li'):
-        title = item.get_text(strip=True)
-        Contest.objects.get_or_create(title=title, url=PCI_URL)
+        for item in soup.select('.caixa-organizador li'):
+            title = item.get_text(strip=True)
+            Contest.objects.get_or_create(title=title, url=PCI_URL)
+
+
+@shared_task
+def send_update_email(contest_id: int) -> None:
+    """Notify users that a contest was updated."""
+    contest = Contest.objects.get(id=contest_id)
+    emails = list(contest.favorite_set.select_related('user').values_list('user__email', flat=True))
+    if emails:
+        send_mail(
+            f'Edital atualizado: {contest.title}',
+            f'O concurso {contest.title} foi atualizado.',
+            'noreply@example.com',
+            emails,
+            fail_silently=True,
+        )

--- a/mydjangoapp/apps/users/migrations/0001_initial.py
+++ b/mydjangoapp/apps/users/migrations/0001_initial.py
@@ -1,0 +1,41 @@
+from django.db import migrations, models
+import django.contrib.auth.models
+import django.utils.timezone
+
+
+class Migration(migrations.Migration):
+
+    initial = True
+
+    dependencies = [
+        ('auth', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='User',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('password', models.CharField(max_length=128, verbose_name='password')),
+                ('last_login', models.DateTimeField(blank=True, null=True, verbose_name='last login')),
+                ('is_superuser', models.BooleanField(default=False, help_text='Designates that this user has all permissions without explicitly assigning them.', verbose_name='superuser status')),
+                ('username', models.CharField(error_messages={'unique': 'A user with that username already exists.'}, help_text='Required. 150 characters or fewer. Letters, digits and @/./+/-/_ only.', max_length=150, unique=True, validators=[django.contrib.auth.models.UnicodeUsernameValidator()], verbose_name='username')),
+                ('first_name', models.CharField(blank=True, max_length=150, verbose_name='first name')),
+                ('last_name', models.CharField(blank=True, max_length=150, verbose_name='last name')),
+                ('email', models.EmailField(blank=True, max_length=254, verbose_name='email address')),
+                ('is_staff', models.BooleanField(default=False, help_text='Designates whether the user can log into this admin site.', verbose_name='staff status')),
+                ('is_active', models.BooleanField(default=True, help_text='Designates whether this user should be treated as active. Unselect this instead of deleting accounts.', verbose_name='active')),
+                ('date_joined', models.DateTimeField(default=django.utils.timezone.now, verbose_name='date joined')),
+                ('groups', models.ManyToManyField(blank=True, help_text='The groups this user belongs to.', related_name='user_set', related_query_name='user', to='auth.group', verbose_name='groups')),
+                ('user_permissions', models.ManyToManyField(blank=True, help_text='Specific permissions for this user.', related_name='user_set', related_query_name='user', to='auth.permission', verbose_name='user permissions')),
+            ],
+            options={
+                'verbose_name': 'user',
+                'verbose_name_plural': 'users',
+                'abstract': False,
+            },
+            managers=[
+                ('objects', django.contrib.auth.models.UserManager()),
+            ],
+        ),
+    ]

--- a/mydjangoapp/apps/users/models.py
+++ b/mydjangoapp/apps/users/models.py
@@ -1,1 +1,9 @@
-# Usuários personalizados podem ser implementados aqui
+from django.contrib.auth.models import AbstractUser
+
+
+class User(AbstractUser):
+    """Default user model extending ``AbstractUser``."""
+
+    def __str__(self) -> str:  # pragma: no cover - trivial
+        return self.username
+

--- a/mydjangoapp/apps/users/views.py
+++ b/mydjangoapp/apps/users/views.py
@@ -1,0 +1,20 @@
+from django.contrib.auth.decorators import login_required
+from django.http import HttpResponseRedirect
+from django.shortcuts import get_object_or_404
+from django.urls import reverse
+
+from apps.core.models import Contest, Favorite
+
+
+@login_required
+def add_favorite(request, contest_id):
+    contest = get_object_or_404(Contest, id=contest_id)
+    Favorite.objects.get_or_create(user=request.user, contest=contest)
+    return HttpResponseRedirect(reverse('contest_list'))
+
+
+@login_required
+def remove_favorite(request, contest_id):
+    contest = get_object_or_404(Contest, id=contest_id)
+    Favorite.objects.filter(user=request.user, contest=contest).delete()
+    return HttpResponseRedirect(reverse('contest_list'))

--- a/mydjangoapp/config/settings/base.py
+++ b/mydjangoapp/config/settings/base.py
@@ -12,6 +12,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'apps.users',
     'apps.core',
 ]
 MIDDLEWARE = [
@@ -47,3 +48,6 @@ DATABASES = {
 }
 STATIC_URL = 'static/'
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+
+AUTH_USER_MODEL = 'users.User'
+EMAIL_BACKEND = 'django.core.mail.backends.locmem.EmailBackend'

--- a/mydjangoapp/config/urls.py
+++ b/mydjangoapp/config/urls.py
@@ -1,8 +1,11 @@
 from django.contrib import admin
 from django.urls import path
 from apps.core import views
+from apps.users import views as user_views
 
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('', views.contest_list, name='contest_list'),
+    path('contest/<int:contest_id>/favorite/', user_views.add_favorite, name='add_favorite'),
+    path('contest/<int:contest_id>/unfavorite/', user_views.remove_favorite, name='remove_favorite'),
 ]

--- a/mydjangoapp/tests/test_favorites.py
+++ b/mydjangoapp/tests/test_favorites.py
@@ -1,0 +1,34 @@
+from django.contrib.auth import get_user_model
+from django.core import mail
+from django.test import TestCase, override_settings
+from django.urls import reverse
+
+from apps.core.models import Contest, Favorite
+
+
+class FavoriteViewsTest(TestCase):
+    def setUp(self):
+        self.user = get_user_model().objects.create_user('u', 'u@example.com', 'pass')
+        self.contest = Contest.objects.create(title='C1', url='https://c1.com')
+        self.client.login(username='u', password='pass')
+
+    def test_add_and_remove_favorite(self):
+        self.client.post(reverse('add_favorite', args=[self.contest.id]))
+        assert Favorite.objects.filter(user=self.user, contest=self.contest).exists()
+
+        self.client.post(reverse('remove_favorite', args=[self.contest.id]))
+        assert not Favorite.objects.filter(user=self.user, contest=self.contest).exists()
+
+
+@override_settings(CELERY_TASK_ALWAYS_EAGER=True)
+class FavoriteEmailTest(TestCase):
+    def setUp(self):
+        self.user = get_user_model().objects.create_user('u2', 'u2@example.com', 'pass')
+        self.contest = Contest.objects.create(title='C2', url='https://c2.com')
+        Favorite.objects.create(user=self.user, contest=self.contest)
+
+    def test_email_sent_on_update(self):
+        self.contest.title = 'C2 updated'
+        self.contest.save()
+        assert len(mail.outbox) == 1
+        assert 'C2 updated' in mail.outbox[0].subject


### PR DESCRIPTION
## Summary
- add custom user model and configure `AUTH_USER_MODEL`
- create a Favorite model tied to contests
- send email when a favorited contest is updated
- expose add/remove favorite views
- test adding/removing favorites and notifications

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6844aa9de110832fb84019612657936a