### PR TITLE
Add advanced contest filters

### DIFF
--- a/mydjangoapp/apps/core/migrations/0002_extend_contest.py
+++ b/mydjangoapp/apps/core/migrations/0002_extend_contest.py
@@ -1,0 +1,26 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('core', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='contest',
+            name='job_title',
+            field=models.CharField(max_length=255, blank=True),
+        ),
+        migrations.AddField(
+            model_name='contest',
+            name='education_level',
+            field=models.CharField(max_length=255, blank=True),
+        ),
+        migrations.AddField(
+            model_name='contest',
+            name='salary',
+            field=models.PositiveIntegerField(null=True, blank=True),
+        ),
+    ]

--- a/mydjangoapp/apps/core/models.py
+++ b/mydjangoapp/apps/core/models.py
@@ -5,6 +5,9 @@ class Contest(models.Model):
     organization = models.CharField(max_length=255, blank=True)
     state = models.CharField(max_length=2, blank=True)
     deadline = models.DateField(null=True, blank=True)
+    job_title = models.CharField(max_length=255, blank=True)
+    education_level = models.CharField(max_length=255, blank=True)
+    salary = models.PositiveIntegerField(null=True, blank=True)
     url = models.URLField()
 
     def __str__(self):

--- a/mydjangoapp/apps/core/tasks.py
+++ b/mydjangoapp/apps/core/tasks.py
@@ -12,5 +12,19 @@ def fetch_contests():
     soup = BeautifulSoup(response.text, 'html.parser')
     # Esta é apenas uma ilustração simplificada
     for item in soup.select('.caixa-organizador li'):
-        title = item.get_text(strip=True)
-        Contest.objects.get_or_create(title=title, url=PCI_URL)
+        text = item.get_text(strip=True)
+        parts = [p.strip() for p in text.split('|')]
+        title = parts[0]
+        job_title = parts[1] if len(parts) > 1 else ''
+        education = parts[2] if len(parts) > 2 else ''
+        salary = int(parts[3]) if len(parts) > 3 and parts[3].isdigit() else None
+
+        Contest.objects.get_or_create(
+            title=title,
+            url=PCI_URL,
+            defaults={
+                'job_title': job_title,
+                'education_level': education,
+                'salary': salary,
+            },
+        )

--- a/mydjangoapp/apps/core/views.py
+++ b/mydjangoapp/apps/core/views.py
@@ -10,4 +10,13 @@ def contest_list(request):
     state = request.GET.get('state')
     if state:
         contests = contests.filter(state__iexact=state)
+    job_title = request.GET.get('job_title')
+    if job_title:
+        contests = contests.filter(job_title__icontains=job_title)
+    education = request.GET.get('education_level')
+    if education:
+        contests = contests.filter(education_level__icontains=education)
+    salary = request.GET.get('salary')
+    if salary and salary.isdigit():
+        contests = contests.filter(salary__gte=int(salary))
     return render(request, 'contest_list.html', {'contests': contests})

--- a/mydjangoapp/templates/contest_list.html
+++ b/mydjangoapp/templates/contest_list.html
@@ -8,11 +8,17 @@
 <form method="get">
     <input type="text" name="q" placeholder="Buscar" value="{{ request.GET.q }}">
     <input type="text" name="state" placeholder="UF" value="{{ request.GET.state }}">
+    <input type="text" name="job_title" placeholder="Cargo" value="{{ request.GET.job_title }}">
+    <input type="text" name="education_level" placeholder="Escolaridade" value="{{ request.GET.education_level }}">
+    <input type="text" name="salary" placeholder="Salário mínimo" value="{{ request.GET.salary }}">
     <button type="submit">Filtrar</button>
 </form>
 <ul>
 {% for contest in contests %}
-    <li><a href="{{ contest.url }}">{{ contest.title }}</a> - {{ contest.state }}</li>
+    <li>
+        <a href="{{ contest.url }}">{{ contest.title }}</a> - {{ contest.state }} -
+        {{ contest.job_title }} - {{ contest.education_level }} - {{ contest.salary }}
+    </li>
 {% empty %}
     <li>Nenhum concurso encontrado.</li>
 {% endfor %}

--- a/mydjangoapp/tests/test_tasks.py
+++ b/mydjangoapp/tests/test_tasks.py
@@ -11,8 +11,8 @@ class FetchContestsTaskTest(TestCase):
         html = """
             <div class='caixa-organizador'>
                 <ul>
-                    <li>Concurso C</li>
-                    <li>Concurso D</li>
+                    <li>Concurso C | Analista | Superior | 7000</li>
+                    <li>Concurso D | Tecnico | Médio | 3000</li>
                 </ul>
             </div>
         """
@@ -20,6 +20,12 @@ class FetchContestsTaskTest(TestCase):
             m.get(PCI_URL, text=html)
             fetch_contests()
 
-        titles = set(Contest.objects.values_list("title", flat=True))
-        assert titles == {"Concurso C", "Concurso D"}
+        c = Contest.objects.get(title="Concurso C")
+        assert c.job_title == "Analista"
+        assert c.education_level == "Superior"
+        assert c.salary == 7000
+        d = Contest.objects.get(title="Concurso D")
+        assert d.job_title == "Tecnico"
+        assert d.education_level == "Médio"
+        assert d.salary == 3000
 

--- a/mydjangoapp/tests/test_views.py
+++ b/mydjangoapp/tests/test_views.py
@@ -6,8 +6,22 @@ from apps.core.models import Contest
 
 class ContestListViewTest(TestCase):
     def setUp(self):
-        Contest.objects.create(title="Concurso A", url="https://a.com", state="SP")
-        Contest.objects.create(title="Concurso B", url="https://b.com", state="RJ")
+        Contest.objects.create(
+            title="Concurso A",
+            url="https://a.com",
+            state="SP",
+            job_title="Analista",
+            education_level="Superior",
+            salary=5000,
+        )
+        Contest.objects.create(
+            title="Concurso B",
+            url="https://b.com",
+            state="RJ",
+            job_title="Tecnico",
+            education_level="Médio",
+            salary=3000,
+        )
 
     def test_status_ok(self):
         response = self.client.get(reverse("contest_list"))
@@ -26,4 +40,25 @@ class ContestListViewTest(TestCase):
         content = response.content.decode()
         assert "Concurso B" in content
         assert "Concurso A" not in content
+
+    def test_filter_by_job_title(self):
+        response = self.client.get(reverse("contest_list"), {"job_title": "Analista"})
+        assert response.status_code == 200
+        content = response.content.decode()
+        assert "Concurso A" in content
+        assert "Concurso B" not in content
+
+    def test_filter_by_education_level(self):
+        response = self.client.get(reverse("contest_list"), {"education_level": "Médio"})
+        assert response.status_code == 200
+        content = response.content.decode()
+        assert "Concurso B" in content
+        assert "Concurso A" not in content
+
+    def test_filter_by_salary(self):
+        response = self.client.get(reverse("contest_list"), {"salary": "4000"})
+        assert response.status_code == 200
+        content = response.content.decode()
+        assert "Concurso A" in content
+        assert "Concurso B" not in content
 


### PR DESCRIPTION
## Summary
- extend `Contest` model with job title, education level and salary
- populate these fields when scraping contests
- allow filtering by these parameters in the view
- expose filter inputs in the template
- cover new filters in tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6844aa9e2eb4832f86762343367ed2ba