### PR TITLE
Add celery beat schedule tests

### DIFF
--- a/mydjangoapp/apps/core/migrations/0002_schedule_fetch_contests.py
+++ b/mydjangoapp/apps/core/migrations/0002_schedule_fetch_contests.py
@@ -1,0 +1,34 @@
+from django.db import migrations
+
+
+def create_schedule(apps, schema_editor):
+    CrontabSchedule = apps.get_model("django_celery_beat", "CrontabSchedule")
+    PeriodicTask = apps.get_model("django_celery_beat", "PeriodicTask")
+    schedule, _ = CrontabSchedule.objects.get_or_create(minute="0", hour="*/6")
+    PeriodicTask.objects.get_or_create(
+        name="Fetch contests every 6 hours",
+        task="apps.core.tasks.fetch_contests",
+        crontab=schedule,
+    )
+
+
+def delete_schedule(apps, schema_editor):
+    PeriodicTask = apps.get_model("django_celery_beat", "PeriodicTask")
+    try:
+        task = PeriodicTask.objects.get(task="apps.core.tasks.fetch_contests")
+        schedule = task.crontab
+        task.delete()
+        if schedule and not PeriodicTask.objects.filter(crontab=schedule).exists():
+            schedule.delete()
+    except PeriodicTask.DoesNotExist:
+        pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("core", "0001_initial"),
+        ("django_celery_beat", "0001_initial"),
+    ]
+
+    operations = [migrations.RunPython(create_schedule, delete_schedule)]

--- a/mydjangoapp/config/celery.py
+++ b/mydjangoapp/config/celery.py
@@ -1,8 +1,9 @@
 import os
 from celery import Celery
 
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'config.settings.dev')
-app = Celery('mydjangoapp')
-app.config_from_object('django.conf:settings', namespace='CELERY')
-app.conf.broker_url = os.getenv('CELERY_BROKER_URL', 'redis://redis:6379/0')
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings.dev")
+app = Celery("mydjangoapp")
+app.config_from_object("django.conf:settings", namespace="CELERY")
+app.conf.broker_url = os.getenv("CELERY_BROKER_URL", "redis://redis:6379/0")
+app.conf.beat_scheduler = "django_celery_beat.schedulers:DatabaseScheduler"
 app.autodiscover_tasks()

--- a/mydjangoapp/config/settings/base.py
+++ b/mydjangoapp/config/settings/base.py
@@ -2,48 +2,49 @@ import os
 from pathlib import Path
 
 BASE_DIR = Path(__file__).resolve().parent.parent.parent
-SECRET_KEY = os.getenv('DJANGO_SECRET_KEY', 'change-me')
+SECRET_KEY = os.getenv("DJANGO_SECRET_KEY", "change-me")
 DEBUG = False
-ALLOWED_HOSTS = ['*']
+ALLOWED_HOSTS = ["*"]
 INSTALLED_APPS = [
-    'django.contrib.admin',
-    'django.contrib.auth',
-    'django.contrib.contenttypes',
-    'django.contrib.sessions',
-    'django.contrib.messages',
-    'django.contrib.staticfiles',
-    'apps.core',
+    "django.contrib.admin",
+    "django.contrib.auth",
+    "django.contrib.contenttypes",
+    "django.contrib.sessions",
+    "django.contrib.messages",
+    "django.contrib.staticfiles",
+    "django_celery_beat",
+    "apps.core",
 ]
 MIDDLEWARE = [
-    'django.middleware.security.SecurityMiddleware',
-    'django.contrib.sessions.middleware.SessionMiddleware',
-    'django.middleware.common.CommonMiddleware',
-    'django.middleware.csrf.CsrfViewMiddleware',
-    'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.messages.middleware.MessageMiddleware',
+    "django.middleware.security.SecurityMiddleware",
+    "django.contrib.sessions.middleware.SessionMiddleware",
+    "django.middleware.common.CommonMiddleware",
+    "django.middleware.csrf.CsrfViewMiddleware",
+    "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "django.contrib.messages.middleware.MessageMiddleware",
 ]
-ROOT_URLCONF = 'config.urls'
+ROOT_URLCONF = "config.urls"
 TEMPLATES = [
     {
-        'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [BASE_DIR / 'templates'],
-        'APP_DIRS': True,
-        'OPTIONS': {
-            'context_processors': [
-                'django.template.context_processors.debug',
-                'django.template.context_processors.request',
-                'django.contrib.auth.context_processors.auth',
-                'django.contrib.messages.context_processors.messages',
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "DIRS": [BASE_DIR / "templates"],
+        "APP_DIRS": True,
+        "OPTIONS": {
+            "context_processors": [
+                "django.template.context_processors.debug",
+                "django.template.context_processors.request",
+                "django.contrib.auth.context_processors.auth",
+                "django.contrib.messages.context_processors.messages",
             ],
         },
     },
 ]
-WSGI_APPLICATION = 'config.wsgi.application'
+WSGI_APPLICATION = "config.wsgi.application"
 DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': BASE_DIR / 'db.sqlite3',
+    "default": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": BASE_DIR / "db.sqlite3",
     }
 }
-STATIC_URL = 'static/'
-DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+STATIC_URL = "static/"
+DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"

--- a/mydjangoapp/pyproject.toml
+++ b/mydjangoapp/pyproject.toml
@@ -8,11 +8,13 @@ authors = ["Seu Nome <voce@example.com>"]
 python = "^3.12"
 django = "^5.2"
 celery = "^5.3"
+django-celery-beat = "^2.5"
 requests = "^2.31"
 beautifulsoup4 = "^4.12"
 
 [tool.poetry.dev-dependencies]
 pytest = "^8.2"
+pytest-django = "^4.7"
 ruff = "^0.1"
 black = "^23.7"
 requests-mock = "^1.12"

--- a/mydjangoapp/tests/test_beat.py
+++ b/mydjangoapp/tests/test_beat.py
@@ -1,0 +1,9 @@
+from django.test import TestCase
+from django_celery_beat.models import PeriodicTask
+
+
+class BeatScheduleTest(TestCase):
+    def test_fetch_contests_task_scheduled(self):
+        assert PeriodicTask.objects.filter(
+            task="apps.core.tasks.fetch_contests"
+        ).exists()

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+DJANGO_SETTINGS_MODULE = config.settings.dev
+python_files = tests/test_*.py
+


### PR DESCRIPTION
## Summary
- integrate django-celery-beat
- configure celery to use the database scheduler
- schedule periodic scraping with a data migration
- verify the beat schedule in tests
- ensure pytest uses development settings

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6844aa9eaa98832fbfe3b3d9e644a7ff